### PR TITLE
Pin Runestone dependency to minor version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "Runestone",
-        "repositoryURL": "git@github.com:simonbs/Runestone.git",
+        "repositoryURL": "https://github.com/simonbs/Runestone",
         "state": {
-          "branch": "main",
-          "revision": "ed4f6b3cb9ff724405aa060c420eff256c4d6791",
-          "version": null
+          "branch": null,
+          "revision": "2cb46f942488629a991a8f26213f18a8f6d4ccdd",
+          "version": "0.1.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -109,7 +109,7 @@ let package = Package(
         .library(name: "TreeSitterYAMLRunestone", targets: ["TreeSitterYAMLRunestone"]),
     ],
     dependencies: [
-        .package(name: "Runestone", url: "git@github.com:simonbs/Runestone.git", branch: "main")
+        .package(url: "https://github.com/simonbs/Runestone", .upToNextMinor(from: "0.1.1"))
     ],
     targets: [
         .target(name: "TreeSitterLanguagesCommon"),


### PR DESCRIPTION
This should allow for consumers of this library to bring a compatible version of Runestone along that isn't the `HEAD` of Runestone's `main` branch.

Additionally, I needed to change the SSH-style URL to an HTTPS URL for Xcode to actually resolve the package properly for a pinned version.